### PR TITLE
Switch to .NET 9 and set up default file directory

### DIFF
--- a/Controllers/FileController.cs
+++ b/Controllers/FileController.cs
@@ -4,9 +4,7 @@ using System.IO;
 
 namespace TestProject.Controllers;
 
-/// <summary>
-/// Web API for browsing and manipulating files within a configured root directory.
-/// </summary>
+// Web API for browsing and manipulating files within a configured root directory.
 [ApiController]
 [Route("api/files")]
 public class FileController : ControllerBase
@@ -14,12 +12,14 @@ public class FileController : ControllerBase
     private readonly string _root;
     private readonly ILogger<FileController> _logger;
 
+    // Pull the root path from options and normalize it.
     public FileController(IOptions<FileExplorerOptions> options, ILogger<FileController> logger)
     {
         _root = Path.GetFullPath(options.Value.RootPath ?? Directory.GetCurrentDirectory());
         _logger = logger;
     }
 
+    // Convert a user supplied path into one rooted under the configured directory.
     private string ResolvePath(string? relative)
     {
         relative ??= string.Empty;

--- a/DefaultDirectory/readme.txt
+++ b/DefaultDirectory/readme.txt
@@ -1,0 +1,1 @@
+Place your files here.

--- a/FileExplorerOptions.cs
+++ b/FileExplorerOptions.cs
@@ -4,9 +4,7 @@ namespace TestProject;
 
 public class FileExplorerOptions
 {
-    /// <summary>
-    /// Root directory for all file system operations.
-    /// </summary>
-    public string RootPath { get; set; } = Directory.GetCurrentDirectory();
+    // Root directory for all file operations ("A server side home directory should be configurable via variable."). Uses a safe default folder.
+    public string RootPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "DefaultDirectory");
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,15 +1,21 @@
+using System.IO;
+
 namespace TestProject {
     public class Program {
         public static void Main(string[] args) {
             var builder = WebApplication.CreateBuilder(args);
 
-            // Add services to the container.
+            var defaultRoot = Path.Combine(AppContext.BaseDirectory, "DefaultDirectory");
+            if (!Directory.Exists(defaultRoot)) {
+                Directory.CreateDirectory(defaultRoot);
+                File.WriteAllText(Path.Combine(defaultRoot, "readme.txt"), "Drop files here.");
+            }
+
             builder.Services.AddControllers();
             builder.Services.Configure<FileExplorerOptions>(builder.Configuration.GetSection("FileExplorer"));
 
             var app = builder.Build();
 
-            // Configure the HTTP request pipeline.
             app.UseHttpsRedirection();
             app.UseDefaultFiles();
             app.UseStaticFiles();

--- a/TestProject.Tests/TestProject.Tests.csproj
+++ b/TestProject.Tests/TestProject.Tests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/TestProject.csproj
+++ b/TestProject.csproj
@@ -1,13 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="wwwroot\index.html" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="DefaultDirectory/**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- target .NET 9 for both app and tests, updating test packages accordingly
- introduce a safe default directory with placeholder file and simplified comments
- clarify path comments per review feedback

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b838b9a75c8326ac62a0a5afec793d