### PR TITLE
Configure HTTPS redirection port for tests

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,7 @@ namespace TestProject {
             }
 
             builder.Services.AddControllers();
+            builder.Services.AddHttpsRedirection(options => options.HttpsPort = 5001);
             builder.Services.Configure<FileExplorerOptions>(builder.Configuration.GetSection("FileExplorer"));
 
             var app = builder.Build();


### PR DESCRIPTION
## Summary
- configure HTTPS redirection port to 5001

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b849947d508326b134292072af410d