### PR TITLE
Adjust root listing test to account for sample geo files

### DIFF
--- a/TestProject.Tests/FileControllerTests.cs
+++ b/TestProject.Tests/FileControllerTests.cs
@@ -49,8 +49,10 @@ public class FileControllerTests : IAsyncLifetime
         Assert.NotNull(result);
         Assert.Contains("sub", result!.Directories);
         Assert.Contains(result.Files, f => f.Name == "root.txt");
+        Assert.Contains(result.Files, f => f.Name == "point.geojson");
+        Assert.Contains(result.Files, f => f.Name == "point.kml");
         Assert.Equal(1, result.Stats.DirectoryCount);
-        Assert.Equal(1, result.Stats.FileCount);
+        Assert.Equal(3, result.Stats.FileCount);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- include sample geo files in root listing test
- update expected root file count

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b85f2ca20883268c274bc351bb4cec