### PR TITLE
Add folder creation API and improve file actions

### DIFF
--- a/Controllers/FileController.cs
+++ b/Controllers/FileController.cs
@@ -86,6 +86,16 @@ public class FileController : ControllerBase
         return Ok();
     }
 
+    [HttpPost("mkdir")]
+    public IActionResult CreateDirectory([FromQuery] string path)
+    {
+        var full = ResolvePath(path);
+        if (System.IO.File.Exists(full))
+            return Conflict();
+        Directory.CreateDirectory(full);
+        return Ok();
+    }
+
     [HttpDelete]
     public IActionResult Delete([FromQuery] string path)
     {
@@ -97,7 +107,19 @@ public class FileController : ControllerBase
         else
             return NotFound();
 
+        CleanupEmptyDirectories(Path.GetDirectoryName(full)!);
         return Ok();
+    }
+
+    private void CleanupEmptyDirectories(string? directory)
+    {
+        while (!string.IsNullOrEmpty(directory) && directory.StartsWith(_root) && directory != _root)
+        {
+            if (Directory.EnumerateFileSystemEntries(directory).Any())
+                break;
+            Directory.Delete(directory);
+            directory = Path.GetDirectoryName(directory);
+        }
     }
 
     public record PathRequest(string From, string To);

--- a/TestProject.Tests/FileControllerTests.cs
+++ b/TestProject.Tests/FileControllerTests.cs
@@ -75,6 +75,27 @@ public class FileControllerTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task Delete_RemovesEmptyParentDirectories()
+    {
+        Directory.CreateDirectory(Path.Combine(_rootDir, "a", "b"));
+        File.WriteAllText(Path.Combine(_rootDir, "a", "b", "c.txt"), "hi");
+        var client = _factory.CreateClient();
+        var response = await client.DeleteAsync("/api/files?path=" + Uri.EscapeDataString("a/b/c.txt"));
+        response.EnsureSuccessStatusCode();
+        Assert.False(Directory.Exists(Path.Combine(_rootDir, "a", "b")));
+        Assert.False(Directory.Exists(Path.Combine(_rootDir, "a")));
+    }
+
+    [Fact]
+    public async Task Mkdir_CreatesDirectory()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync("/api/files/mkdir?path=newdir", null);
+        response.EnsureSuccessStatusCode();
+        Assert.True(Directory.Exists(Path.Combine(_rootDir, "newdir")));
+    }
+
+    [Fact]
     public async Task Move_RenamesFile()
     {
         var client = _factory.CreateClient();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -12,6 +12,7 @@
         <button id="searchBtn">Search</button>
         <input type="file" id="uploadFile" />
         <button id="uploadBtn">Upload</button>
+        <button id="createFolderBtn">Create Folder</button>
         <button id="zipBtn">Download Zip</button>
         <span id="progress"></span>
     </div>
@@ -52,9 +53,9 @@
                     const enc = encodeURIComponent(newPath);
                     li.innerHTML = `<input type="checkbox" class="select" data-path="${enc}" /> ` +
                         `<a href="?path=${encodeURIComponent(newPath)}">${d}/</a>` +
-                        ` <button onclick="del('${enc}')">del</button>` +
-                        ` <button onclick="movePrompt('${enc}')">move</button>` +
-                        ` <button onclick="copyPrompt('${enc}')">copy</button>`;
+                        ` <button onclick="deletePath('${enc}')">delete</button>` +
+                        ` <button onclick="movePath('${enc}')">move</button>` +
+                        ` <button onclick="copyPath('${enc}')">copy</button>`;
                     list.appendChild(li);
                 });
 
@@ -69,9 +70,9 @@
                     li.innerHTML = `<input type="checkbox" class="select" data-path="${enc}" /> ` +
                         `${f.name} (${f.size} bytes) <a href="${apiBase}/download?path=${encodeURIComponent(filePath)}">download</a>` +
                         preview +
-                        ` <button onclick="del('${enc}')">del</button>` +
-                        ` <button onclick="movePrompt('${enc}')">move</button>` +
-                        ` <button onclick="copyPrompt('${enc}')">copy</button>`;
+                        ` <button onclick="deletePath('${enc}')">delete</button>` +
+                        ` <button onclick="movePath('${enc}')">move</button>` +
+                        ` <button onclick="copyPath('${enc}')">copy</button>`;
                     list.appendChild(li);
                 });
 
@@ -99,6 +100,14 @@
                     fetch(apiBase + '/search?query=' + encodeURIComponent(q))
                         .then(r => r.json())
                         .then(showSearch);
+                };
+
+                document.getElementById('createFolderBtn').onclick = () => {
+                    const name = prompt('Folder name:');
+                    if (!name) return;
+                    const newPath = (path ? path + '/' : '') + name;
+                    fetch(apiBase + '/mkdir?path=' + encodeURIComponent(newPath), { method: 'POST' })
+                        .then(() => load());
                 };
 
                 document.getElementById('zipBtn').onclick = async () => {
@@ -151,33 +160,30 @@
         document.getElementById('stats').textContent = 'Search results';
     }
 
-    function del(p) {
+    function deletePath(p) {
         const path = decodeURIComponent(p);
         if (!confirm('Delete ' + path + '?')) return;
         fetch(apiBase + '?path=' + encodeURIComponent(path), { method: 'DELETE' })
             .then(() => load());
     }
 
-    function movePrompt(p) {
+    function promptAndPost(p, url, message) {
         const path = decodeURIComponent(p);
-        const dest = prompt('Move to:', path);
+        const dest = prompt(message, path);
         if (!dest) return;
-        fetch(apiBase + '/move', {
+        fetch(apiBase + url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ from: path, to: dest })
         }).then(() => load());
     }
 
-    function copyPrompt(p) {
-        const path = decodeURIComponent(p);
-        const dest = prompt('Copy to:', path);
-        if (!dest) return;
-        fetch(apiBase + '/copy', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ from: path, to: dest })
-        }).then(() => load());
+    function movePath(p) {
+        promptAndPost(p, '/move', 'Move to:');
+    }
+
+    function copyPath(p) {
+        promptAndPost(p, '/copy', 'Copy to:');
     }
 
     let map;


### PR DESCRIPTION
## Summary
- Rename JS move/copy helpers for consistent `*Path` naming and extract shared prompt logic
- Delete endpoint now removes empty parent directories for cleaner structure
- Add test verifying empty directory cleanup after file deletion

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b8778308888326984aaf6badb53815