### PR TITLE
Add generic file preview and KML support

### DIFF
--- a/Controllers/FileController.cs
+++ b/Controllers/FileController.cs
@@ -2,9 +2,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using System.IO;
 using System.IO.Compression;
-using System.Globalization;
-using System.Text.Json;
-using System.Xml.Linq;
 
 namespace TestProject.Controllers;
 
@@ -71,6 +68,8 @@ public class FileController : ControllerBase
     }
 
     [HttpPost("upload")]
+    [RequestSizeLimit(long.MaxValue)]
+    [RequestFormLimits(MultipartBodyLengthLimit = long.MaxValue)]
     public async Task<IActionResult> Upload([FromQuery] string? path, IFormFile file)
     {
         if (file == null || file.Length == 0)
@@ -230,97 +229,6 @@ public class FileController : ControllerBase
             var targetDirPath = Path.Combine(destDir, Path.GetFileName(directory));
             CopyDirectory(directory, targetDirPath);
         }
-    }
-
-    [HttpGet("geo-preview")]
-    public IActionResult GeoPreview([FromQuery] string path)
-    {
-        var full = ResolvePath(path);
-        if (!System.IO.File.Exists(full))
-            return NotFound();
-
-        var ext = Path.GetExtension(full).ToLowerInvariant();
-        string geojson;
-        if (ext == ".geojson" || ext == ".json")
-        {
-            geojson = System.IO.File.ReadAllText(full);
-        }
-        else if (ext == ".kml")
-        {
-            var kml = System.IO.File.ReadAllText(full);
-            geojson = KmlToGeoJson(kml);
-        }
-        else
-        {
-            return BadRequest("Unsupported file type");
-        }
-
-        return Content(geojson, "application/geo+json");
-    }
-
-    private static string KmlToGeoJson(string kmlContent)
-    {
-        var doc = XDocument.Parse(kmlContent);
-        XNamespace ns = doc.Root!.Name.Namespace;
-        var features = new List<object>();
-
-        static double[] ParseLonLat(string coord)
-        {
-            var parts = coord.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            var lon = double.Parse(parts[0], CultureInfo.InvariantCulture);
-            var lat = double.Parse(parts[1], CultureInfo.InvariantCulture);
-            return new[] { lon, lat };
-        }
-
-        static double[][] ParseCoordinateList(string coordText) =>
-            coordText.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
-                     .Select(ParseLonLat)
-                     .ToArray();
-
-        foreach (var pm in doc.Descendants(ns + "Placemark"))
-        {
-            var name = pm.Element(ns + "name")?.Value;
-            object? geometry = null;
-
-            var point = pm.Element(ns + "Point");
-            if (point != null)
-            {
-                var coordText = point.Element(ns + "coordinates")?.Value.Trim();
-                if (!string.IsNullOrEmpty(coordText))
-                {
-                    geometry = new { type = "Point", coordinates = ParseLonLat(coordText) };
-                }
-            }
-
-            var line = pm.Element(ns + "LineString");
-            if (geometry == null && line != null)
-            {
-                var coordText = line.Element(ns + "coordinates")?.Value;
-                if (!string.IsNullOrEmpty(coordText))
-                {
-                    geometry = new { type = "LineString", coordinates = ParseCoordinateList(coordText) };
-                }
-            }
-
-            var poly = pm.Element(ns + "Polygon");
-            if (geometry == null && poly != null)
-            {
-                var coordText = poly.Descendants(ns + "outerBoundaryIs").Descendants(ns + "coordinates").FirstOrDefault()?.Value;
-                if (!string.IsNullOrEmpty(coordText))
-                {
-                    var coords = ParseCoordinateList(coordText);
-                    geometry = new { type = "Polygon", coordinates = new[] { coords } };
-                }
-            }
-
-            if (geometry != null)
-            {
-                features.Add(new { type = "Feature", properties = new { name }, geometry });
-            }
-        }
-
-        var fc = new { type = "FeatureCollection", features };
-        return JsonSerializer.Serialize(fc);
     }
 
     [HttpGet("search")]

--- a/Controllers/PreviewController.cs
+++ b/Controllers/PreviewController.cs
@@ -1,0 +1,116 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.StaticFiles;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace TestProject.Controllers;
+
+[ApiController]
+[Route("api/preview")]
+public class PreviewController : ControllerBase
+{
+    private readonly string _root;
+    private readonly FileExtensionContentTypeProvider _contentTypeProvider = new();
+
+    public PreviewController(IOptions<FileExplorerOptions> options)
+    {
+        _root = Path.GetFullPath(options.Value.RootPath ?? Directory.GetCurrentDirectory());
+    }
+
+    private string ResolvePath(string relative)
+    {
+        var combined = Path.GetFullPath(Path.Combine(_root, relative ?? string.Empty));
+        if (!combined.StartsWith(_root))
+            throw new InvalidOperationException("Invalid path");
+        return combined;
+    }
+
+    [HttpGet]
+    public IActionResult Get([FromQuery] string path)
+    {
+        var full = ResolvePath(path);
+        if (!System.IO.File.Exists(full))
+            return NotFound();
+
+        var ext = Path.GetExtension(full).ToLowerInvariant();
+        if (ext == ".kml")
+        {
+            var kml = System.IO.File.ReadAllText(full);
+            var geojson = KmlToGeoJson(kml);
+            return Content(geojson, "application/geo+json");
+        }
+
+        if (!_contentTypeProvider.TryGetContentType(full, out var contentType))
+            contentType = "application/octet-stream";
+
+        return PhysicalFile(full, contentType);
+    }
+
+    private static string KmlToGeoJson(string kmlContent)
+    {
+        var doc = XDocument.Parse(kmlContent);
+        XNamespace ns = doc.Root!.Name.Namespace;
+        var features = new List<object>();
+
+        static double[] ParseLonLat(string coord)
+        {
+            var parts = coord.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var lon = double.Parse(parts[0], CultureInfo.InvariantCulture);
+            var lat = double.Parse(parts[1], CultureInfo.InvariantCulture);
+            return new[] { lon, lat };
+        }
+
+        static double[][] ParseCoordinateList(string coordText) =>
+            coordText.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                     .Select(ParseLonLat)
+                     .ToArray();
+
+        foreach (var pm in doc.Descendants(ns + "Placemark"))
+        {
+            var name = pm.Element(ns + "name")?.Value;
+            object? geometry = null;
+
+            var point = pm.Element(ns + "Point");
+            if (point != null)
+            {
+                var coordText = point.Element(ns + "coordinates")?.Value.Trim();
+                if (!string.IsNullOrEmpty(coordText))
+                {
+                    geometry = new { type = "Point", coordinates = ParseLonLat(coordText) };
+                }
+            }
+
+            var line = pm.Element(ns + "LineString");
+            if (geometry == null && line != null)
+            {
+                var coordText = line.Element(ns + "coordinates")?.Value;
+                if (!string.IsNullOrEmpty(coordText))
+                {
+                    geometry = new { type = "LineString", coordinates = ParseCoordinateList(coordText) };
+                }
+            }
+
+            var poly = pm.Element(ns + "Polygon");
+            if (geometry == null && poly != null)
+            {
+                var coordText = poly.Descendants(ns + "outerBoundaryIs").Descendants(ns + "coordinates").FirstOrDefault()?.Value;
+                if (!string.IsNullOrEmpty(coordText))
+                {
+                    var coords = ParseCoordinateList(coordText);
+                    geometry = new { type = "Polygon", coordinates = new[] { coords } };
+                }
+            }
+
+            if (geometry != null)
+            {
+                features.Add(new { type = "Feature", properties = new { name }, geometry });
+            }
+        }
+
+        var fc = new { type = "FeatureCollection", features };
+        return JsonSerializer.Serialize(fc);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace TestProject {
     public class Program {
@@ -14,6 +15,9 @@ namespace TestProject {
             builder.Services.AddControllers();
             builder.Services.AddHttpsRedirection(options => options.HttpsPort = 5001);
             builder.Services.Configure<FileExplorerOptions>(builder.Configuration.GetSection("FileExplorer"));
+            builder.Services.Configure<FormOptions>(o => o.MultipartBodyLengthLimit = long.MaxValue);
+
+            builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = long.MaxValue);
 
             var app = builder.Build();
 

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -1,0 +1,262 @@
+const apiBase = '/api/files';
+const previewApi = '/api/preview';
+const selected = new Set();
+const previewableExt = new Set([
+    '.txt', '.json', '.xml', '.csv', '.kml', '.geojson',
+    '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp', '.svg'
+]);
+
+function showSpinner() {
+    document.getElementById('spinner').classList.add('show');
+}
+
+function hideSpinner() {
+    document.getElementById('spinner').classList.remove('show');
+}
+
+async function apiFetch(url, options) {
+    showSpinner();
+    try {
+        const res = await fetch(url, options);
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(text || res.statusText);
+        }
+        return res;
+    } catch (err) {
+        alert('Error: ' + err.message);
+        throw err;
+    } finally {
+        hideSpinner();
+    }
+}
+
+function isPreviewable(name) {
+    const dot = name.lastIndexOf('.');
+    if (dot === -1) return false;
+    return previewableExt.has(name.substring(dot).toLowerCase());
+}
+
+async function load() {
+    const params = new URLSearchParams(window.location.search);
+    const path = params.get('path') || '';
+    try {
+        const r = await apiFetch(apiBase + '?path=' + encodeURIComponent(path));
+        const data = await r.json();
+        document.getElementById('stats').textContent =
+            `Folders: ${data.stats.directoryCount}, Files: ${data.stats.fileCount}, Size: ${data.stats.totalSize} bytes`;
+
+        const list = document.getElementById('listing');
+        list.innerHTML = '';
+        selected.clear();
+
+        if (path) {
+            const parent = path.split('/').slice(0, -1).join('/');
+            const li = document.createElement('li');
+            li.innerHTML = `<a href="?path=${encodeURIComponent(parent)}">..</a>`;
+            list.appendChild(li);
+        }
+
+        data.directories.forEach(d => {
+            const li = document.createElement('li');
+            const newPath = (path ? path + '/' : '') + d;
+            const enc = encodeURIComponent(newPath);
+            li.innerHTML = `<input type="checkbox" class="select" data-path="${enc}" /> ` +
+                `<a href="?path=${encodeURIComponent(newPath)}">${d}/</a>` +
+                ` <button onclick="deletePath('${enc}')">delete</button>` +
+                ` <button onclick="movePath('${enc}')">move</button>` +
+                ` <button onclick="copyPath('${enc}')">copy</button>`;
+            list.appendChild(li);
+        });
+
+        data.files.forEach(f => {
+            const li = document.createElement('li');
+            const filePath = (path ? path + '/' : '') + f.name;
+            const enc = encodeURIComponent(filePath);
+            let html = `<input type="checkbox" class="select" data-path="${enc}" /> ` +
+                `${f.name} (${f.size} bytes) <a href="${apiBase}/download?path=${encodeURIComponent(filePath)}">download</a>`;
+            if (isPreviewable(f.name)) {
+                html += ` <button onclick="preview('${enc}')">preview</button>`;
+            }
+            html += ` <button onclick="deletePath('${enc}')">delete</button>` +
+                ` <button onclick="movePath('${enc}')">move</button>` +
+                ` <button onclick="copyPath('${enc}')">copy</button>`;
+            li.innerHTML = html;
+            list.appendChild(li);
+        });
+
+        document.querySelectorAll('.select').forEach(cb => {
+            cb.onchange = () => {
+                const p = decodeURIComponent(cb.dataset.path);
+                if (cb.checked) selected.add(p); else selected.delete(p);
+            };
+        });
+
+        document.getElementById('uploadBtn').onclick = async () => {
+            const fileInput = document.getElementById('uploadFile');
+            const file = fileInput.files[0];
+            if (!file) return;
+            const form = new FormData();
+            form.append('file', file);
+            try {
+                await apiFetch(apiBase + '/upload?path=' + encodeURIComponent(path), {
+                    method: 'POST',
+                    body: form
+                });
+                load();
+            } catch {}
+        };
+
+        document.getElementById('searchBtn').onclick = async () => {
+            const q = document.getElementById('search').value;
+            try {
+                const r = await apiFetch(apiBase + '/search?query=' + encodeURIComponent(q));
+                const d = await r.json();
+                showSearch(d);
+            } catch {}
+        };
+
+        document.getElementById('createFolderBtn').onclick = async () => {
+            const name = prompt('Folder name:');
+            if (!name) return;
+            const newPath = (path ? path + '/' : '') + name;
+            try {
+                await apiFetch(apiBase + '/mkdir?path=' + encodeURIComponent(newPath), { method: 'POST' });
+                load();
+            } catch {}
+        };
+
+        document.getElementById('zipBtn').onclick = async () => {
+            if (selected.size === 0) return;
+            try {
+                const res = await apiFetch(apiBase + '/zip', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ paths: Array.from(selected) })
+                });
+                const total = parseInt(res.headers.get('Content-Length')) || 0;
+                const reader = res.body.getReader();
+                let received = 0;
+                const chunks = [];
+                const progress = document.getElementById('progress');
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    chunks.push(value);
+                    received += value.length;
+                    if (total) progress.textContent = `Downloading... ${(received / total * 100).toFixed(1)}%`;
+                }
+                progress.textContent = '';
+                const blob = new Blob(chunks, { type: 'application/zip' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'files.zip';
+                a.click();
+                URL.revokeObjectURL(url);
+                selected.clear();
+                document.querySelectorAll('.select').forEach(cb => cb.checked = false);
+            } catch {}
+        };
+    } catch {}
+}
+
+function showSearch(data) {
+    const list = document.getElementById('listing');
+    list.innerHTML = '';
+    data.directories.forEach(d => {
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>Dir:</strong> <a href="?path=${encodeURIComponent(d.path)}">${d.path}</a>`;
+        list.appendChild(li);
+    });
+    data.files.forEach(f => {
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>File:</strong> ${f.path} (${f.size} bytes) <a href="${apiBase}/download?path=${encodeURIComponent(f.path)}">download</a>`;
+        list.appendChild(li);
+    });
+    document.getElementById('stats').textContent = 'Search results';
+}
+
+async function deletePath(p) {
+    const path = decodeURIComponent(p);
+    if (!confirm('Delete ' + path + '?')) return;
+    try {
+        await apiFetch(apiBase + '?path=' + encodeURIComponent(path), { method: 'DELETE' });
+        load();
+    } catch {}
+}
+
+async function promptAndPost(p, url, message) {
+    const path = decodeURIComponent(p);
+    const dest = prompt(message, path);
+    if (!dest) return;
+    try {
+        await apiFetch(apiBase + url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ from: path, to: dest })
+        });
+        load();
+    } catch {}
+}
+
+function movePath(p) {
+    promptAndPost(p, '/move', 'Move to:');
+}
+
+function copyPath(p) {
+    promptAndPost(p, '/copy', 'Copy to:');
+}
+
+let map;
+
+async function preview(p) {
+    const path = decodeURIComponent(p);
+    try {
+        const r = await apiFetch(previewApi + '?path=' + encodeURIComponent(path));
+        const dlg = document.getElementById('previewDialog');
+        const container = document.getElementById('previewContainer');
+        const ct = r.headers.get('Content-Type') || '';
+        dlg.showModal();
+        if (ct.includes('application/geo+json')) {
+            const data = await r.json();
+            container.innerHTML = '<div id="map" style="width:100%;height:100%;"></div>';
+            if (map) {
+                map.remove();
+            }
+            map = L.map('map');
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '© OpenStreetMap contributors'
+            }).addTo(map);
+            const layer = L.geoJSON(data).addTo(map);
+            const bounds = layer.getBounds();
+            if (bounds.isValid()) {
+                map.fitBounds(bounds);
+            }
+        } else if (ct.startsWith('image/')) {
+            const blob = await r.blob();
+            const url = URL.createObjectURL(blob);
+            container.innerHTML = `<img src="${url}" style="max-width:100%;max-height:100%;" />`;
+        } else {
+            const text = await r.text();
+            container.innerHTML = `<pre style="white-space:pre-wrap;">${escapeHtml(text)}</pre>`;
+        }
+    } catch {}
+}
+
+function escapeHtml(str) {
+    return str.replace(/[&<>'"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+document.getElementById('closePreview').onclick = () => {
+    document.getElementById('previewDialog').close();
+    const container = document.getElementById('previewContainer');
+    container.innerHTML = '';
+    if (map) {
+        map.remove();
+        map = null;
+    }
+};
+
+window.onload = load;
+

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -104,7 +104,9 @@ async function load() {
                     body: form
                 });
                 load();
-            } catch {}
+            } catch (err) {
+                console.error(err);
+            }
         };
 
         document.getElementById('searchBtn').onclick = async () => {
@@ -113,7 +115,9 @@ async function load() {
                 const r = await apiFetch(apiBase + '/search?query=' + encodeURIComponent(q));
                 const d = await r.json();
                 showSearch(d);
-            } catch {}
+            } catch (err) {
+                console.error(err);
+            }
         };
 
         document.getElementById('createFolderBtn').onclick = async () => {
@@ -123,7 +127,9 @@ async function load() {
             try {
                 await apiFetch(apiBase + '/mkdir?path=' + encodeURIComponent(newPath), { method: 'POST' });
                 load();
-            } catch {}
+            } catch (err) {
+                console.error(err);
+            }
         };
 
         document.getElementById('zipBtn').onclick = async () => {
@@ -156,9 +162,13 @@ async function load() {
                 URL.revokeObjectURL(url);
                 selected.clear();
                 document.querySelectorAll('.select').forEach(cb => cb.checked = false);
-            } catch {}
+            } catch (err) {
+                console.error(err);
+            }
         };
-    } catch {}
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 function showSearch(data) {
@@ -183,7 +193,9 @@ async function deletePath(p) {
     try {
         await apiFetch(apiBase + '?path=' + encodeURIComponent(path), { method: 'DELETE' });
         load();
-    } catch {}
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 async function promptAndPost(p, url, message) {
@@ -197,7 +209,9 @@ async function promptAndPost(p, url, message) {
             body: JSON.stringify({ from: path, to: dest })
         });
         load();
-    } catch {}
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 function movePath(p) {
@@ -241,7 +255,9 @@ async function preview(p) {
             const text = await r.text();
             container.innerHTML = `<pre style="white-space:pre-wrap;">${escapeHtml(text)}</pre>`;
         }
-    } catch {}
+    } catch (err) {
+        console.error(err);
+    }
 }
 
 function escapeHtml(str) {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -4,8 +4,15 @@
     <meta charset="utf-8" />
     <title>File Explorer</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        #spinner { display:none; position:fixed; top:0; left:0; width:100%; height:100%;
+            background:rgba(0,0,0,0.3); color:#fff; font-size:2em; align-items:center;
+            justify-content:center; z-index:1000; }
+        #spinner.show { display:flex; }
+    </style>
 </head>
 <body>
+    <div id="spinner">Loading...</div>
     <h1>File Explorer</h1>
     <div id="controls">
         <input type="text" id="search" placeholder="Search" />
@@ -19,211 +26,10 @@
     <div id="stats"></div>
     <ul id="listing"></ul>
     <dialog id="previewDialog" style="width:80%;height:80%;">
-        <div id="map" style="width:100%;height:90%;"></div>
+        <div id="previewContainer" style="width:100%;height:90%;"></div>
         <button id="closePreview">Close</button>
     </dialog>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-    <script>
-    const apiBase = '/api/files';
-    const selected = new Set();
-
-    function load() {
-        const params = new URLSearchParams(window.location.search);
-        const path = params.get('path') || '';
-        fetch(apiBase + '?path=' + encodeURIComponent(path))
-            .then(r => r.json())
-            .then(data => {
-                document.getElementById('stats').textContent =
-                    `Folders: ${data.stats.directoryCount}, Files: ${data.stats.fileCount}, Size: ${data.stats.totalSize} bytes`;
-
-                const list = document.getElementById('listing');
-                list.innerHTML = '';
-                selected.clear();
-
-                if (path) {
-                    const parent = path.split('/').slice(0, -1).join('/');
-                    const li = document.createElement('li');
-                    li.innerHTML = `<a href="?path=${encodeURIComponent(parent)}">..</a>`;
-                    list.appendChild(li);
-                }
-
-                data.directories.forEach(d => {
-                    const li = document.createElement('li');
-                    const newPath = (path ? path + '/' : '') + d;
-                    const enc = encodeURIComponent(newPath);
-                    li.innerHTML = `<input type="checkbox" class="select" data-path="${enc}" /> ` +
-                        `<a href="?path=${encodeURIComponent(newPath)}">${d}/</a>` +
-                        ` <button onclick="deletePath('${enc}')">delete</button>` +
-                        ` <button onclick="movePath('${enc}')">move</button>` +
-                        ` <button onclick="copyPath('${enc}')">copy</button>`;
-                    list.appendChild(li);
-                });
-
-                data.files.forEach(f => {
-                    const li = document.createElement('li');
-                    const filePath = (path ? path + '/' : '') + f.name;
-                    const enc = encodeURIComponent(filePath);
-                    let preview = '';
-                    if (/\.geojson$/i.test(f.name) || /\.kml$/i.test(f.name)) {
-                        preview = ` <button onclick="preview('${enc}')">preview</button>`;
-                    }
-                    li.innerHTML = `<input type="checkbox" class="select" data-path="${enc}" /> ` +
-                        `${f.name} (${f.size} bytes) <a href="${apiBase}/download?path=${encodeURIComponent(filePath)}">download</a>` +
-                        preview +
-                        ` <button onclick="deletePath('${enc}')">delete</button>` +
-                        ` <button onclick="movePath('${enc}')">move</button>` +
-                        ` <button onclick="copyPath('${enc}')">copy</button>`;
-                    list.appendChild(li);
-                });
-
-                document.querySelectorAll('.select').forEach(cb => {
-                    cb.onchange = () => {
-                        const p = decodeURIComponent(cb.dataset.path);
-                        if (cb.checked) selected.add(p); else selected.delete(p);
-                    };
-                });
-
-                document.getElementById('uploadBtn').onclick = () => {
-                    const fileInput = document.getElementById('uploadFile');
-                    const file = fileInput.files[0];
-                    if (!file) return;
-                    const form = new FormData();
-                    form.append('file', file);
-                    fetch(apiBase + '/upload?path=' + encodeURIComponent(path), {
-                        method: 'POST',
-                        body: form
-                    }).then(() => load());
-                };
-
-                document.getElementById('searchBtn').onclick = () => {
-                    const q = document.getElementById('search').value;
-                    fetch(apiBase + '/search?query=' + encodeURIComponent(q))
-                        .then(r => r.json())
-                        .then(showSearch);
-                };
-
-                document.getElementById('createFolderBtn').onclick = () => {
-                    const name = prompt('Folder name:');
-                    if (!name) return;
-                    const newPath = (path ? path + '/' : '') + name;
-                    fetch(apiBase + '/mkdir?path=' + encodeURIComponent(newPath), { method: 'POST' })
-                        .then(() => load());
-                };
-
-                document.getElementById('zipBtn').onclick = async () => {
-                    if (selected.size === 0) return;
-                    const res = await fetch(apiBase + '/zip', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ paths: Array.from(selected) })
-                    });
-                    if (!res.ok) return;
-                    const total = parseInt(res.headers.get('Content-Length')) || 0;
-                    const reader = res.body.getReader();
-                    let received = 0;
-                    const chunks = [];
-                    const progress = document.getElementById('progress');
-                    while (true) {
-                        const { done, value } = await reader.read();
-                        if (done) break;
-                        chunks.push(value);
-                        received += value.length;
-                        if (total) progress.textContent = `Downloading... ${(received / total * 100).toFixed(1)}%`;
-                    }
-                    progress.textContent = '';
-                    const blob = new Blob(chunks, { type: 'application/zip' });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = 'files.zip';
-                    a.click();
-                    URL.revokeObjectURL(url);
-                    selected.clear();
-                    document.querySelectorAll('.select').forEach(cb => cb.checked = false);
-                };
-            });
-    }
-
-    function showSearch(data) {
-        const list = document.getElementById('listing');
-        list.innerHTML = '';
-        data.directories.forEach(d => {
-            const li = document.createElement('li');
-            li.innerHTML = `<strong>Dir:</strong> <a href="?path=${encodeURIComponent(d.path)}">${d.path}</a>`;
-            list.appendChild(li);
-        });
-        data.files.forEach(f => {
-            const li = document.createElement('li');
-            li.innerHTML = `<strong>File:</strong> ${f.path} (${f.size} bytes) <a href="${apiBase}/download?path=${encodeURIComponent(f.path)}">download</a>`;
-            list.appendChild(li);
-        });
-        document.getElementById('stats').textContent = 'Search results';
-    }
-
-    function deletePath(p) {
-        const path = decodeURIComponent(p);
-        if (!confirm('Delete ' + path + '?')) return;
-        fetch(apiBase + '?path=' + encodeURIComponent(path), { method: 'DELETE' })
-            .then(() => load());
-    }
-
-    function promptAndPost(p, url, message) {
-        const path = decodeURIComponent(p);
-        const dest = prompt(message, path);
-        if (!dest) return;
-        fetch(apiBase + url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ from: path, to: dest })
-        }).then(() => load());
-    }
-
-    function movePath(p) {
-        promptAndPost(p, '/move', 'Move to:');
-    }
-
-    function copyPath(p) {
-        promptAndPost(p, '/copy', 'Copy to:');
-    }
-
-    let map;
-    let currentLayer;
-
-    function preview(p) {
-        const path = decodeURIComponent(p);
-        fetch(apiBase + '/geo-preview?path=' + encodeURIComponent(path))
-            .then(r => r.json())
-            .then(data => {
-                const dlg = document.getElementById('previewDialog');
-                dlg.showModal();
-                if (!map) {
-                    map = L.map('map');
-                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                        attribution: '© OpenStreetMap contributors'
-                    }).addTo(map);
-                } else {
-                    map.invalidateSize();
-                }
-                if (currentLayer) {
-                    map.removeLayer(currentLayer);
-                }
-                currentLayer = L.geoJSON(data).addTo(map);
-                const bounds = currentLayer.getBounds();
-                if (bounds.isValid()) {
-                    map.fitBounds(bounds);
-                }
-            });
-    }
-
-    document.getElementById('closePreview').onclick = () => {
-        document.getElementById('previewDialog').close();
-        if (currentLayer) {
-            map.removeLayer(currentLayer);
-            currentLayer = null;
-        }
-    };
-
-    window.onload = load;
-    </script>
+    <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow large file uploads by raising server request limits
- add spinner and global error handling for all API calls
- show preview button only for supported text and image types, retaining KML map support

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_68b87dde128c8326b0868619e34c0291