### PR TITLE
Remove automatic empty directory cleanup

### DIFF
--- a/Controllers/FileController.cs
+++ b/Controllers/FileController.cs
@@ -106,19 +106,7 @@ public class FileController : ControllerBase
         else
             return NotFound();
 
-        CleanupEmptyDirectories(Path.GetDirectoryName(full)!);
         return Ok();
-    }
-
-    private void CleanupEmptyDirectories(string? directory)
-    {
-        while (!string.IsNullOrEmpty(directory) && directory.StartsWith(_root) && directory != _root)
-        {
-            if (Directory.EnumerateFileSystemEntries(directory).Any())
-                break;
-            Directory.Delete(directory);
-            directory = Path.GetDirectoryName(directory);
-        }
     }
 
     public record PathRequest(string From, string To);


### PR DESCRIPTION
## Summary
- Stop deleting empty parent folders when removing files or directories.
- Drop unused `CleanupEmptyDirectories` helper.

## Testing
- `dotnet test` *(fails: FileControllerTests.cs(123,27): error CS0246: The type or namespace name 'MultipartFormDataContent' could not be found...)*

------
https://chatgpt.com/codex/tasks/task_e_68b88c01e3988326846b69910f341d4e