### PR TITLE
Add missing Http namespace for tests

### DIFF
--- a/TestProject.Tests/FileControllerTests.cs
+++ b/TestProject.Tests/FileControllerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;


### PR DESCRIPTION
## Summary
- fix FileControllerTests by importing System.Net.Http

## Testing
- `dotnet test` (fails: Delete_RemovesEmptyParentDirectories)


------
https://chatgpt.com/codex/tasks/task_e_68b891528f4483268b199064b6568881