### PR TITLE
Document .NET 6 and add search back navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,34 @@
 # Server File Explorer
 
-A minimal .NET 9 project that exposes an API and single-page app for browsing files on the server.
+An end‑to‑end .NET 6 project that exposes a JSON Web API and a single‑page app for browsing files on the server.
 
-## Features
-- List directories and files with counts and sizes
-- Upload and download files
-- Search within the configured home directory
+## Setup
+Requires the .NET 6 SDK.
 
-## Running
-```
+```bash
 dotnet run
 ```
+
 The app listens on http://localhost:5000 and https://localhost:5001. On first run it creates a `DefaultDirectory` with a placeholder file so project sources stay isolated.
 
-## Testing
-```
+Run tests with:
+
+```bash
 dotnet test
 ```
+
+## Project requirements covered
+- Web API that browses and searches files and folders
+- Single page app with deep‑linkable URLs (`?path=...`)
+- Upload and download files from the browser
+- Show file and folder counts and total size for the current view
+
+## Additional features
+- Preview text, images and geospatial files (KML converted to GeoJSON) in a dialog
+- Create directories
+- Delete files or folders
+- Move or copy files and folders
+- Download multiple selections as a ZIP archive
 
 ## Configuration
 The root folder for all file operations is `FileExplorer:RootPath` in *appsettings.json* or the `FileExplorer__RootPath` environment variable. By default it points to the `DefaultDirectory` folder.

--- a/wwwroot/app.js
+++ b/wwwroot/app.js
@@ -40,6 +40,7 @@ function isPreviewable(name) {
 async function load() {
     const params = new URLSearchParams(window.location.search);
     const path = params.get('path') || '';
+    document.getElementById('backBtn').style.display = 'none';
     try {
         const r = await apiFetch(apiBase + '?path=' + encodeURIComponent(path));
         const data = await r.json();
@@ -185,6 +186,12 @@ function showSearch(data) {
         list.appendChild(li);
     });
     document.getElementById('stats').textContent = 'Search results';
+    const back = document.getElementById('backBtn');
+    back.style.display = 'inline';
+    back.onclick = () => {
+        document.getElementById('search').value = '';
+        load();
+    };
 }
 
 async function deletePath(p) {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -21,6 +21,7 @@
         <button id="uploadBtn">Upload</button>
         <button id="createFolderBtn">Create Folder</button>
         <button id="zipBtn">Download Zip</button>
+        <button id="backBtn" style="display:none">&#8592; Back to explorer</button>
         <span id="progress"></span>
     </div>
     <div id="stats"></div>


### PR DESCRIPTION
## Summary
- Correct README to reflect .NET 6 SDK requirement
- Add a "Back to explorer" button on search results and hide it during normal browsing

## Testing
- `/root/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b8987d3538832689ca50fab9190aae