### PR TITLE
Refactor path handling with shared service and tests

### DIFF
--- a/Controllers/PreviewController.cs
+++ b/Controllers/PreviewController.cs
@@ -1,10 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
 using Microsoft.AspNetCore.StaticFiles;
 using System.Globalization;
 using System.IO;
 using System.Text.Json;
 using System.Xml.Linq;
+using TestProject.Services;
 
 namespace TestProject.Controllers;
 
@@ -12,26 +12,18 @@ namespace TestProject.Controllers;
 [Route("api/preview")]
 public class PreviewController : ControllerBase
 {
-    private readonly string _root;
+    private readonly PathResolver _resolver;
     private readonly FileExtensionContentTypeProvider _contentTypeProvider = new();
 
-    public PreviewController(IOptions<FileExplorerOptions> options)
+    public PreviewController(PathResolver resolver)
     {
-        _root = Path.GetFullPath(options.Value.RootPath ?? Directory.GetCurrentDirectory());
-    }
-
-    private string ResolvePath(string relative)
-    {
-        var combined = Path.GetFullPath(Path.Combine(_root, relative ?? string.Empty));
-        if (!combined.StartsWith(_root))
-            throw new InvalidOperationException("Invalid path");
-        return combined;
+        _resolver = resolver;
     }
 
     [HttpGet]
     public IActionResult Get([FromQuery] string path)
     {
-        var full = ResolvePath(path);
+        var full = _resolver.ResolvePath(path);
         if (!System.IO.File.Exists(full))
             return NotFound();
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using Microsoft.AspNetCore.Http.Features;
+using TestProject.Services;
 
 namespace TestProject {
     public class Program {
@@ -15,6 +16,7 @@ namespace TestProject {
             builder.Services.AddControllers();
             builder.Services.AddHttpsRedirection(options => options.HttpsPort = 5001);
             builder.Services.Configure<FileExplorerOptions>(builder.Configuration.GetSection("FileExplorer"));
+            builder.Services.AddSingleton<PathResolver>();
             builder.Services.Configure<FormOptions>(o => o.MultipartBodyLengthLimit = long.MaxValue);
 
             builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = long.MaxValue);

--- a/Services/PathResolver.cs
+++ b/Services/PathResolver.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using Microsoft.Extensions.Options;
+
+namespace TestProject.Services;
+
+public class PathResolver
+{
+    private readonly string _root;
+
+    public PathResolver(IOptions<FileExplorerOptions> options)
+    {
+        _root = Path.GetFullPath(options.Value.RootPath ?? Directory.GetCurrentDirectory());
+    }
+
+    public string RootPath => _root;
+
+    public string ResolvePath(string? relative)
+    {
+        relative ??= string.Empty;
+        var combined = Path.GetFullPath(Path.Combine(_root, relative));
+        if (!combined.StartsWith(_root))
+            throw new InvalidOperationException("Invalid path");
+        return combined;
+    }
+}

--- a/TestProject.Tests/PathResolverTests.cs
+++ b/TestProject.Tests/PathResolverTests.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Options;
+using TestProject.Services;
+using Xunit;
+
+namespace TestProject.Tests;
+
+public class PathResolverTests
+{
+    [Fact]
+    public void ResolvePath_ValidPath_ReturnsFullPath()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(root);
+        try
+        {
+            var options = Options.Create(new FileExplorerOptions { RootPath = root });
+            var resolver = new PathResolver(options);
+            var full = resolver.ResolvePath("sub/file.txt");
+            Assert.Equal(Path.GetFullPath(Path.Combine(root, "sub/file.txt")), full);
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public void ResolvePath_InvalidPath_Throws()
+    {
+        var root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(root);
+        try
+        {
+            var options = Options.Create(new FileExplorerOptions { RootPath = root });
+            var resolver = new PathResolver(options);
+            Assert.Throws<InvalidOperationException>(() => resolver.ResolvePath("../outside.txt"));
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PathResolver` service to normalize and validate filesystem paths
- inject `PathResolver` into controllers and remove duplicated logic
- add unit tests for valid and invalid path resolution

## Testing
- `dotnet test TestProject.sln` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a052d3088326a011caa62491fcb1