### PR TITLE
Fix SPA initialization to prevent invalid path parameter

### DIFF
--- a/wwwroot/js/app.js
+++ b/wwwroot/js/app.js
@@ -6,7 +6,9 @@ const selected = new Set();
 let map;
 
 async function load(p) {
-    const path = p !== undefined ? p : (new URLSearchParams(window.location.search).get('path') || '');
+    const path = typeof p === 'string'
+        ? p
+        : (new URLSearchParams(window.location.search).get('path') || '');
     document.getElementById('backBtn').style.display = 'none';
     try {
         const data = await api.listDirectory(path);
@@ -208,7 +210,7 @@ document.getElementById('closePreview').onclick = () => {
         map = null;
     }
 };
-window.onload = load;
+window.addEventListener('load', () => load());
 window.onpopstate = () => {
     const params = new URLSearchParams(location.search);
     const path = params.get('path') || '';


### PR DESCRIPTION
## Summary
- Handle non-string parameters to `load` and default to URL query path
- Use explicit window load event handler to avoid passing event object

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b91502aec883269deef0c86be48f2c