### PR TITLE
Replace global spinner with skeleton loader

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -5,14 +5,21 @@
     <title>File Explorer</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
     <style>
-        #spinner { display:none; position:fixed; top:0; left:0; width:100%; height:100%;
-            background:rgba(0,0,0,0.3); color:#fff; font-size:2em; align-items:center;
-            justify-content:center; z-index:1000; }
-        #spinner.show { display:flex; }
+        .skeleton {
+            height: 1.2em;
+            margin: 0.5em 0;
+            border-radius: 4px;
+            background-color: #eee;
+            animation: pulse 1s ease-in-out infinite;
+        }
+        @keyframes pulse {
+            0% { background-color: #eee; }
+            50% { background-color: #ddd; }
+            100% { background-color: #eee; }
+        }
     </style>
 </head>
 <body>
-    <div id="spinner">Loading...</div>
     <h1>File Explorer</h1>
     <div id="controls">
         <input type="text" id="search" placeholder="Search" />

--- a/wwwroot/js/app.js
+++ b/wwwroot/js/app.js
@@ -9,13 +9,15 @@ async function load(p) {
     const path = typeof p === 'string'
         ? p
         : (new URLSearchParams(window.location.search).get('path') || '');
+    const list = document.getElementById('listing');
+    list.innerHTML = '<li class="skeleton"></li><li class="skeleton"></li><li class="skeleton"></li>';
+    document.getElementById('stats').textContent = '';
     document.getElementById('backBtn').style.display = 'none';
     try {
         const data = await api.listDirectory(path);
         document.getElementById('stats').textContent =
             `Folders: ${data.stats.directoryCount}, Files: ${data.stats.fileCount}, Size: ${data.stats.totalSize} bytes`;
 
-        const list = document.getElementById('listing');
         list.innerHTML = '';
         selected.clear();
 

--- a/wwwroot/js/util.js
+++ b/wwwroot/js/util.js
@@ -1,19 +1,4 @@
-export function showSpinner() {
-    const el = document.getElementById('spinner');
-    if (el) {
-        el.classList.add('show');
-    }
-}
-
-export function hideSpinner() {
-    const el = document.getElementById('spinner');
-    if (el) {
-        el.classList.remove('show');
-    }
-}
-
 export async function apiFetch(url, options) {
-    showSpinner();
     try {
         const res = await fetch(url, options);
         if (!res.ok) {
@@ -26,11 +11,10 @@ export async function apiFetch(url, options) {
             alert('Error: ' + err.message);
         }
         throw err;
-    } finally {
-        hideSpinner();
     }
 }
 
 export function escapeHtml(str) {
     return str.replace(/[&<>'"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 }
+


### PR DESCRIPTION
## Summary
- remove blocking page spinner and add lightweight skeleton animation
- streamline fetch utility without spinner hooks
- show skeleton entries while directory listing loads

## Testing
- `dotnet test` *(fails: You must install or update .NET to run this application)*

------
https://chatgpt.com/codex/tasks/task_e_68b9214540f083268b9a30df8f65a3e2