### PR TITLE
Harden path resolution to prevent traversal

### DIFF
--- a/Services/PathResolver.cs
+++ b/Services/PathResolver.cs
@@ -17,7 +17,8 @@ public class PathResolver
     {
         relative ??= string.Empty;
         var combined = Path.GetFullPath(Path.Combine(_root, relative));
-        if (!combined.StartsWith(_root))
+        var relativePath = Path.GetRelativePath(_root, combined);
+        if (relativePath.StartsWith("..", StringComparison.Ordinal) || !combined.StartsWith(_root, StringComparison.OrdinalIgnoreCase))
             throw new InvalidOperationException("Invalid path");
         return combined;
     }

--- a/TestProject.Tests/PathResolverTests.cs
+++ b/TestProject.Tests/PathResolverTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using Microsoft.Extensions.Options;
+using TestProject;
+using TestProject.Services;
+using Xunit;
+
+namespace TestProject.Tests;
+
+public class PathResolverTests : IDisposable
+{
+    private readonly string _root;
+    private readonly PathResolver _resolver;
+
+    public PathResolverTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_root);
+        _resolver = new PathResolver(Options.Create(new FileExplorerOptions { RootPath = _root }));
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_root, true);
+    }
+
+    [Theory]
+    [InlineData("../outside.txt")]
+    [InlineData("sub/../../outside.txt")]
+    public void Resolve_DetectsTraversal(string input)
+    {
+        Assert.Throws<InvalidOperationException>(() => _resolver.Resolve(input));
+    }
+
+    [Fact]
+    public void Resolve_DetectsAbsoluteEscape()
+    {
+        var outside = Path.GetFullPath(Path.Combine(_root, "..", "outside.txt"));
+        Assert.Throws<InvalidOperationException>(() => _resolver.Resolve(outside));
+    }
+}


### PR DESCRIPTION
## Summary
- ensure PathResolver only returns paths rooted under configured directory
- add tests covering traversal attempts

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b92acf1e848326a6f2e0520f1191a5