### PR TITLE
refactor: introduce FileExplorer class

### DIFF
--- a/wwwroot/js/preview.js
+++ b/wwwroot/js/preview.js
@@ -1,0 +1,47 @@
+import { escapeHtml } from './util.js';
+import * as api from './api.js';
+
+let mapInstance = null;
+
+export async function showPreview(path) {
+    try {
+        const response = await api.preview(path);
+        const dialog = document.getElementById('previewDialog');
+        const container = document.getElementById('previewContainer');
+        const contentType = response.headers.get('Content-Type') || '';
+        dialog.showModal();
+        if (contentType.includes('application/geo+json')) {
+            const data = await response.json();
+            container.innerHTML = '<div id="map" style="width:100%;height:100%;"></div>';
+            if (mapInstance) {
+                mapInstance.remove();
+            }
+            mapInstance = L.map('map');
+            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(mapInstance);
+            const layer = L.geoJSON(data).addTo(mapInstance);
+            const bounds = layer.getBounds();
+            if (bounds.isValid()) {
+                mapInstance.fitBounds(bounds);
+            }
+        } else if (contentType.startsWith('image/')) {
+            const blob = await response.blob();
+            const url = URL.createObjectURL(blob);
+            container.innerHTML = `<img src="${url}" style="max-width:100%;max-height:100%;" />`;
+        } else {
+            const text = await response.text();
+            container.innerHTML = `<pre style="white-space:pre-wrap;">${escapeHtml(text)}</pre>`;
+        }
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+export function closePreview() {
+    document.getElementById('previewDialog').close();
+    const container = document.getElementById('previewContainer');
+    container.innerHTML = '';
+    if (mapInstance) {
+        mapInstance.remove();
+        mapInstance = null;
+    }
+}

--- a/wwwroot/js/zip.js
+++ b/wwwroot/js/zip.js
@@ -1,0 +1,28 @@
+import * as api from './api.js';
+
+export async function downloadZip(paths, progressElement) {
+    const response = await api.zipPaths(paths);
+    const totalSize = parseInt(response.headers.get('Content-Length')) || 0;
+    const reader = response.body.getReader();
+    let received = 0;
+    const chunks = [];
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        received += value.length;
+        if (totalSize && progressElement) {
+            progressElement.textContent = `Downloading... ${(received / totalSize * 100).toFixed(1)}%`;
+        }
+    }
+    if (progressElement) {
+        progressElement.textContent = '';
+    }
+    const blob = new Blob(chunks, { type: 'application/zip' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'files.zip';
+    link.click();
+    URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- refactor app.js into a FileExplorer class managing state and directory navigation
- extract preview and archive helpers into standalone modules with clearer variable names
- remove OpenStreetMap attribution and improve readability

## Testing
- `dotnet test` *(fails: Microsoft.NETCore.App 6.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b92d24efc48326bd96646d750a2707