### PR TITLE
Use single file system enumeration for search

### DIFF
--- a/TestProject.Tests/FileControllerTests.cs
+++ b/TestProject.Tests/FileControllerTests.cs
@@ -65,10 +65,14 @@ public class FileControllerTests : IAsyncLifetime
     public async Task SearchReturnsMatches()
     {
         var client = _factory.CreateClient();
-        var result = await client.GetFromJsonAsync<SearchResult>("/api/files/search?query=a.txt");
 
-        Assert.NotNull(result);
-        Assert.Contains(result!.Files, f => f.Path.EndsWith("sub/a.txt"));
+        var fileResult = await client.GetFromJsonAsync<SearchResult>("/api/files/search?query=a.txt");
+        Assert.NotNull(fileResult);
+        Assert.Contains(fileResult!.Files, f => f.Path.EndsWith("sub/a.txt"));
+
+        var dirResult = await client.GetFromJsonAsync<SearchResult>("/api/files/search?query=sub");
+        Assert.NotNull(dirResult);
+        Assert.Contains(dirResult!.Directories, d => d.Path == "sub");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- streamline file search by walking all entries once and categorizing results
- extend search tests to verify directory hits alongside files

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a7674c9c83269273acf1170b16c8