### PR TITLE
Centralize file root directory configuration

### DIFF
--- a/FileExplorerOptions.cs
+++ b/FileExplorerOptions.cs
@@ -4,7 +4,9 @@ namespace TestProject;
 
 public class FileExplorerOptions
 {
+    public const string DefaultRootDirectoryName = "DefaultDirectory";
+
     // Root directory for all file work. The spec asks for a configurable home folder, so we default to a sandboxed "DefaultDirectory".
-    public string RootPath { get; set; } = Path.Combine(AppContext.BaseDirectory, "DefaultDirectory");
+    public string RootPath { get; set; } = Path.Combine(AppContext.BaseDirectory, DefaultRootDirectoryName);
 }
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,17 +1,12 @@
 using System.IO;
-using TestProject.Services;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Options;
+using TestProject.Services;
 
 namespace TestProject {
     public class Program {
         public static void Main(string[] args) {
             var builder = WebApplication.CreateBuilder(args);
-
-            var defaultRoot = Path.Combine(AppContext.BaseDirectory, "DefaultDirectory");
-            if (!Directory.Exists(defaultRoot)) {
-                Directory.CreateDirectory(defaultRoot);
-                File.WriteAllText(Path.Combine(defaultRoot, "readme.txt"), "Drop files here.");
-            }
 
             builder.Services.AddControllers();
             builder.Services.AddHttpsRedirection(options => options.HttpsPort = 5001);
@@ -22,6 +17,11 @@ namespace TestProject {
             builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = long.MaxValue);
 
             var app = builder.Build();
+
+            var options = app.Services.GetRequiredService<IOptions<FileExplorerOptions>>().Value;
+            var rootPath = Path.GetFullPath(options.RootPath);
+            if (!Directory.Exists(rootPath))
+                Directory.CreateDirectory(rootPath);
 
             app.UseHttpsRedirection();
             app.UseDefaultFiles();

--- a/Services/PathResolver.cs
+++ b/Services/PathResolver.cs
@@ -10,7 +10,7 @@ public class PathResolver
 
     public PathResolver(IOptions<FileExplorerOptions> options)
     {
-        _root = Path.GetFullPath(options.Value.RootPath ?? Directory.GetCurrentDirectory());
+        _root = Path.GetFullPath(options.Value.RootPath);
     }
 
     public string Resolve(string? relative)

--- a/appsettings.json
+++ b/appsettings.json
@@ -6,8 +6,4 @@
     }
   },
   "AllowedHosts": "*"
-  ,
-  "FileExplorer": {
-    "RootPath": "DefaultDirectory"
-  }
 }


### PR DESCRIPTION
## Summary
- use `FileExplorerOptions` everywhere to determine root directory
- remove duplicate root path fallbacks
- trim redundant configuration entry
- rely on DI to construct `PathResolver`
- drop placeholder file creation when ensuring root directory exists

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bbba9900e88326ab7a748b8320ff4c