### PR TITLE
Refactor controllers to delegate file logic to services

### DIFF
--- a/Controllers/FileController.cs
+++ b/Controllers/FileController.cs
@@ -1,9 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
-using TestProject.Services;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Collections.Generic;
+using TestProject.Services;
 using TestProject.Models;
 
 namespace TestProject.Controllers;
@@ -13,37 +10,39 @@ namespace TestProject.Controllers;
 [Route("api/files")]
 public class FileController : ControllerBase
 {
-    private readonly PathResolver _pathResolver;
-    private readonly string _root;
+    private readonly FileService _fileService;
 
-    public FileController(PathResolver pathResolver)
+    public FileController(FileService fileService)
     {
-        _pathResolver = pathResolver;
-        _root = _pathResolver.Resolve(null);
+        _fileService = fileService;
     }
 
     [HttpGet]
     public IActionResult Get([FromQuery] string? path)
     {
-        var full = _pathResolver.Resolve(path);
-        if (!Directory.Exists(full))
+        try
+        {
+            var result = _fileService.List(path);
+            return Ok(result);
+        }
+        catch (DirectoryNotFoundException)
+        {
             return NotFound();
-        var directory = new DirectoryInfo(full);
-        var directories = directory.GetDirectories().Select(d => d.Name).ToList();
-        var files = directory.GetFiles().Select(f => new FileItem(f.Name, f.Length)).ToList();
-        var stats = new Stats(directories.Count, files.Count, files.Sum(f => f.Size));
-        var result = new DirectoryListing(path ?? string.Empty, directories, files, stats);
-        return Ok(result);
+        }
     }
 
     [HttpGet("download")]
     public IActionResult Download([FromQuery] string path)
     {
-        var full = _pathResolver.Resolve(path);
-        if (!System.IO.File.Exists(full))
+        try
+        {
+            var info = _fileService.GetDownloadInfo(path);
+            return PhysicalFile(info.FullPath, "application/octet-stream", info.FileName);
+        }
+        catch (FileNotFoundException)
+        {
             return NotFound();
-        var fileName = Path.GetFileName(full);
-        return PhysicalFile(full, "application/octet-stream", fileName);
+        }
     }
 
     [HttpPost("upload")]
@@ -54,37 +53,43 @@ public class FileController : ControllerBase
         if (file == null || file.Length == 0)
             return BadRequest("No file supplied");
 
-        var folder = _pathResolver.Resolve(path);
-        if (!Directory.Exists(folder))
+        try
+        {
+            await _fileService.Upload(path, file);
+            return Ok();
+        }
+        catch (DirectoryNotFoundException)
+        {
             return NotFound();
-
-        var dest = Path.Combine(folder, Path.GetFileName(file.FileName));
-        await using var stream = System.IO.File.Create(dest);
-        await file.CopyToAsync(stream);
-        return Ok();
+        }
     }
 
     [HttpPost("mkdir")]
     public IActionResult CreateDirectory([FromQuery] string path)
     {
-        var full = _pathResolver.Resolve(path);
-        if (System.IO.File.Exists(full))
+        try
+        {
+            _fileService.CreateDirectory(path);
+            return Ok();
+        }
+        catch (IOException)
+        {
             return Conflict();
-        Directory.CreateDirectory(full);
-        return Ok();
+        }
     }
 
     [HttpDelete]
     public IActionResult Delete([FromQuery] string path)
     {
-        var full = _pathResolver.Resolve(path);
-        if (System.IO.File.Exists(full))
-            System.IO.File.Delete(full);
-        else if (Directory.Exists(full))
-            Directory.Delete(full, true);
-        else
+        try
+        {
+            _fileService.Delete(path);
+            return Ok();
+        }
+        catch (FileNotFoundException)
+        {
             return NotFound();
-        return Ok();
+        }
     }
 
     [HttpPost("move")]
@@ -92,9 +97,7 @@ public class FileController : ControllerBase
     {
         try
         {
-            ProcessPath(request.From, request.To,
-                (source, dest) => System.IO.File.Move(source, dest, true),
-                (source, dest) => Directory.Move(source, dest));
+            _fileService.Move(request.From, request.To);
             return Ok();
         }
         catch (FileNotFoundException)
@@ -108,9 +111,7 @@ public class FileController : ControllerBase
     {
         try
         {
-            ProcessPath(request.From, request.To,
-                (source, dest) => System.IO.File.Copy(source, dest, true),
-                (source, dest) => CopyDirectory(source, dest));
+            _fileService.Copy(request.From, request.To);
             return Ok();
         }
         catch (FileNotFoundException)
@@ -124,100 +125,14 @@ public class FileController : ControllerBase
     {
         if (request.Paths == null || request.Paths.Count == 0)
             return BadRequest("No paths supplied");
-        var ms = new MemoryStream();
-        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
-        {
-            foreach (var relative in request.Paths)
-            {
-                var full = _pathResolver.Resolve(relative);
-                await AddToArchive(archive, full);
-            }
-        }
-        ms.Position = 0;
+        var ms = await _fileService.Zip(request.Paths);
         return File(ms, "application/zip", "files.zip");
     }
 
     [HttpGet("search")]
     public IActionResult Search([FromQuery] string query)
     {
-        var files = new List<FoundFile>();
-        var directories = new List<FoundDirectory>();
-
-        foreach (var path in Directory.EnumerateFileSystemEntries(_root, "*", SearchOption.AllDirectories))
-        {
-            var name = Path.GetFileName(path);
-            if (!name.Contains(query, StringComparison.OrdinalIgnoreCase))
-                continue;
-
-            var attributes = System.IO.File.GetAttributes(path);
-            if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
-            {
-                directories.Add(new FoundDirectory(Path.GetRelativePath(_root, path)));
-            }
-            else
-            {
-                files.Add(new FoundFile(Path.GetRelativePath(_root, path), new FileInfo(path).Length));
-            }
-        }
-
-        return Ok(new SearchResult(files, directories));
-    }
-
-    private void ProcessPath(string from, string to, Action<string, string> fileAction, Action<string, string> dirAction)
-    {
-        var source = _pathResolver.Resolve(from);
-        var dest = _pathResolver.Resolve(to);
-        if (System.IO.File.Exists(source))
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-            fileAction(source, dest);
-        }
-        else if (Directory.Exists(source))
-        {
-            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
-            dirAction(source, dest);
-        }
-        else
-        {
-            throw new FileNotFoundException();
-        }
-    }
-
-    private async Task AddToArchive(ZipArchive archive, string fullPath)
-    {
-        if (System.IO.File.Exists(fullPath))
-        {
-            var entryPath = Path.GetRelativePath(_root, fullPath).Replace('\\', '/');
-            var entry = archive.CreateEntry(entryPath, CompressionLevel.Fastest);
-            await using var src = System.IO.File.OpenRead(fullPath);
-            await using var dest = entry.Open();
-            await src.CopyToAsync(dest);
-        }
-        else if (Directory.Exists(fullPath))
-        {
-            foreach (var file in Directory.EnumerateFiles(fullPath, "*", SearchOption.AllDirectories))
-            {
-                var entryPath = Path.GetRelativePath(_root, file).Replace('\\', '/');
-                var entry = archive.CreateEntry(entryPath, CompressionLevel.Fastest);
-                await using var src = System.IO.File.OpenRead(file);
-                await using var dest = entry.Open();
-                await src.CopyToAsync(dest);
-            }
-        }
-    }
-
-    private static void CopyDirectory(string sourceDir, string destDir)
-    {
-        Directory.CreateDirectory(destDir);
-        foreach (var file in Directory.GetFiles(sourceDir))
-        {
-            var targetFilePath = Path.Combine(destDir, Path.GetFileName(file));
-            System.IO.File.Copy(file, targetFilePath, true);
-        }
-        foreach (var directory in Directory.GetDirectories(sourceDir))
-        {
-            var targetDirPath = Path.Combine(destDir, Path.GetFileName(directory));
-            CopyDirectory(directory, targetDirPath);
-        }
+        var result = _fileService.Search(query);
+        return Ok(result);
     }
 }

--- a/Controllers/PreviewController.cs
+++ b/Controllers/PreviewController.cs
@@ -1,10 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.StaticFiles;
-using TestProject.Services;
-using System.Globalization;
 using System.IO;
-using System.Text.Json;
-using System.Xml.Linq;
+using TestProject.Services;
 
 namespace TestProject.Controllers;
 
@@ -12,97 +8,26 @@ namespace TestProject.Controllers;
 [Route("api/preview")]
 public class PreviewController : ControllerBase
 {
-    private readonly PathResolver _pathResolver;
-    private readonly FileExtensionContentTypeProvider _contentTypeProvider = new();
+    private readonly PreviewService _previewService;
 
-    public PreviewController(PathResolver pathResolver)
+    public PreviewController(PreviewService previewService)
     {
-        _pathResolver = pathResolver;
+        _previewService = previewService;
     }
 
     [HttpGet]
     public IActionResult Get([FromQuery] string path)
     {
-        var full = _pathResolver.Resolve(path);
-        if (!System.IO.File.Exists(full))
+        try
+        {
+            var result = _previewService.GetPreview(path);
+            if (result.FilePath != null)
+                return PhysicalFile(result.FilePath, result.ContentType);
+            return Content(result.Content!, result.ContentType);
+        }
+        catch (FileNotFoundException)
+        {
             return NotFound();
-
-        var ext = Path.GetExtension(full).ToLowerInvariant();
-        if (ext == ".kml")
-        {
-            var kml = System.IO.File.ReadAllText(full);
-            var geojson = KmlToGeoJson(kml);
-            return Content(geojson, "application/geo+json");
         }
-
-        if (!_contentTypeProvider.TryGetContentType(full, out var contentType))
-            contentType = "application/octet-stream";
-
-        return PhysicalFile(full, contentType);
-    }
-
-    private static string KmlToGeoJson(string kmlContent)
-    {
-        var doc = XDocument.Parse(kmlContent);
-        XNamespace ns = doc.Root!.Name.Namespace;
-        var features = new List<object>();
-
-        static double[] ParseLonLat(string coord)
-        {
-            var parts = coord.Split(',', StringSplitOptions.RemoveEmptyEntries);
-            var lon = double.Parse(parts[0], CultureInfo.InvariantCulture);
-            var lat = double.Parse(parts[1], CultureInfo.InvariantCulture);
-            return new[] { lon, lat };
-        }
-
-        static double[][] ParseCoordinateList(string coordText) =>
-            coordText.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
-                     .Select(ParseLonLat)
-                     .ToArray();
-
-        foreach (var pm in doc.Descendants(ns + "Placemark"))
-        {
-            var name = pm.Element(ns + "name")?.Value;
-            object? geometry = null;
-
-            var point = pm.Element(ns + "Point");
-            if (point != null)
-            {
-                var coordText = point.Element(ns + "coordinates")?.Value.Trim();
-                if (!string.IsNullOrEmpty(coordText))
-                {
-                    geometry = new { type = "Point", coordinates = ParseLonLat(coordText) };
-                }
-            }
-
-            var line = pm.Element(ns + "LineString");
-            if (geometry == null && line != null)
-            {
-                var coordText = line.Element(ns + "coordinates")?.Value;
-                if (!string.IsNullOrEmpty(coordText))
-                {
-                    geometry = new { type = "LineString", coordinates = ParseCoordinateList(coordText) };
-                }
-            }
-
-            var poly = pm.Element(ns + "Polygon");
-            if (geometry == null && poly != null)
-            {
-                var coordText = poly.Descendants(ns + "outerBoundaryIs").Descendants(ns + "coordinates").FirstOrDefault()?.Value;
-                if (!string.IsNullOrEmpty(coordText))
-                {
-                    var coords = ParseCoordinateList(coordText);
-                    geometry = new { type = "Polygon", coordinates = new[] { coords } };
-                }
-            }
-
-            if (geometry != null)
-            {
-                features.Add(new { type = "Feature", properties = new { name }, geometry });
-            }
-        }
-
-        var fc = new { type = "FeatureCollection", features };
-        return JsonSerializer.Serialize(fc);
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -18,6 +18,8 @@ namespace TestProject {
             builder.Services.Configure<FileExplorerOptions>(builder.Configuration.GetSection("FileExplorer"));
             builder.Services.Configure<FormOptions>(o => o.MultipartBodyLengthLimit = long.MaxValue);
             builder.Services.AddSingleton<PathResolver>();
+            builder.Services.AddSingleton<FileService>();
+            builder.Services.AddSingleton<PreviewService>();
 
             builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = long.MaxValue);
 

--- a/Services/FileService.cs
+++ b/Services/FileService.cs
@@ -1,0 +1,181 @@
+using Microsoft.AspNetCore.Http;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using TestProject.Models;
+
+namespace TestProject.Services;
+
+public class FileService
+{
+    private readonly PathResolver _pathResolver;
+    private readonly string _root;
+
+    public FileService(PathResolver pathResolver)
+    {
+        _pathResolver = pathResolver;
+        _root = _pathResolver.Resolve(null);
+    }
+
+    public DirectoryListing List(string? path)
+    {
+        var full = _pathResolver.Resolve(path);
+        if (!Directory.Exists(full))
+            throw new DirectoryNotFoundException();
+        var directory = new DirectoryInfo(full);
+        var directories = directory.GetDirectories().Select(d => d.Name).ToList();
+        var files = directory.GetFiles().Select(f => new FileItem(f.Name, f.Length)).ToList();
+        var stats = new Stats(directories.Count, files.Count, files.Sum(f => f.Size));
+        return new DirectoryListing(path ?? string.Empty, directories, files, stats);
+    }
+
+    public (string FullPath, string FileName) GetDownloadInfo(string path)
+    {
+        var full = _pathResolver.Resolve(path);
+        if (!File.Exists(full))
+            throw new FileNotFoundException();
+        var fileName = Path.GetFileName(full);
+        return (full, fileName);
+    }
+
+    public async Task Upload(string? path, IFormFile file)
+    {
+        var folder = _pathResolver.Resolve(path);
+        if (!Directory.Exists(folder))
+            throw new DirectoryNotFoundException();
+        var dest = Path.Combine(folder, Path.GetFileName(file.FileName));
+        await using var stream = File.Create(dest);
+        await file.CopyToAsync(stream);
+    }
+
+    public void CreateDirectory(string path)
+    {
+        var full = _pathResolver.Resolve(path);
+        if (File.Exists(full))
+            throw new IOException();
+        Directory.CreateDirectory(full);
+    }
+
+    public void Delete(string path)
+    {
+        var full = _pathResolver.Resolve(path);
+        if (File.Exists(full))
+            File.Delete(full);
+        else if (Directory.Exists(full))
+            Directory.Delete(full, true);
+        else
+            throw new FileNotFoundException();
+    }
+
+    public void Move(string from, string to)
+    {
+        ProcessPath(from, to,
+            (source, dest) => File.Move(source, dest, true),
+            (source, dest) => Directory.Move(source, dest));
+    }
+
+    public void Copy(string from, string to)
+    {
+        ProcessPath(from, to,
+            (source, dest) => File.Copy(source, dest, true),
+            (source, dest) => CopyDirectory(source, dest));
+    }
+
+    public async Task<MemoryStream> Zip(List<string> paths)
+    {
+        var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, true))
+        {
+            foreach (var relative in paths)
+            {
+                var full = _pathResolver.Resolve(relative);
+                await AddToArchive(archive, full);
+            }
+        }
+        ms.Position = 0;
+        return ms;
+    }
+
+    public SearchResult Search(string query)
+    {
+        var files = new List<FoundFile>();
+        var directories = new List<FoundDirectory>();
+
+        foreach (var path in Directory.EnumerateFileSystemEntries(_root, "*", SearchOption.AllDirectories))
+        {
+            var name = Path.GetFileName(path);
+            if (!name.Contains(query, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+            {
+                directories.Add(new FoundDirectory(Path.GetRelativePath(_root, path)));
+            }
+            else
+            {
+                files.Add(new FoundFile(Path.GetRelativePath(_root, path), new FileInfo(path).Length));
+            }
+        }
+
+        return new SearchResult(files, directories);
+    }
+
+    private void ProcessPath(string from, string to, Action<string, string> fileAction, Action<string, string> dirAction)
+    {
+        var source = _pathResolver.Resolve(from);
+        var dest = _pathResolver.Resolve(to);
+        if (File.Exists(source))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            fileAction(source, dest);
+        }
+        else if (Directory.Exists(source))
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dest)!);
+            dirAction(source, dest);
+        }
+        else
+        {
+            throw new FileNotFoundException();
+        }
+    }
+
+    private async Task AddToArchive(ZipArchive archive, string fullPath)
+    {
+        if (File.Exists(fullPath))
+        {
+            var entryPath = Path.GetRelativePath(_root, fullPath).Replace('\\', '/');
+            var entry = archive.CreateEntry(entryPath, CompressionLevel.Fastest);
+            await using var src = File.OpenRead(fullPath);
+            await using var dest = entry.Open();
+            await src.CopyToAsync(dest);
+        }
+        else if (Directory.Exists(fullPath))
+        {
+            foreach (var file in Directory.EnumerateFiles(fullPath, "*", SearchOption.AllDirectories))
+            {
+                var entryPath = Path.GetRelativePath(_root, file).Replace('\\', '/');
+                var entry = archive.CreateEntry(entryPath, CompressionLevel.Fastest);
+                await using var src = File.OpenRead(file);
+                await using var dest = entry.Open();
+                await src.CopyToAsync(dest);
+            }
+        }
+    }
+
+    private static void CopyDirectory(string sourceDir, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+        foreach (var file in Directory.GetFiles(sourceDir))
+        {
+            var targetFilePath = Path.Combine(destDir, Path.GetFileName(file));
+            File.Copy(file, targetFilePath, true);
+        }
+        foreach (var directory in Directory.GetDirectories(sourceDir))
+        {
+            var targetDirPath = Path.Combine(destDir, Path.GetFileName(directory));
+            CopyDirectory(directory, targetDirPath);
+        }
+    }
+}

--- a/Services/PreviewService.cs
+++ b/Services/PreviewService.cs
@@ -1,0 +1,108 @@
+using Microsoft.AspNetCore.StaticFiles;
+using System.Globalization;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace TestProject.Services;
+
+public class PreviewService
+{
+    private readonly PathResolver _pathResolver;
+    private readonly FileExtensionContentTypeProvider _contentTypeProvider = new();
+
+    public PreviewService(PathResolver pathResolver)
+    {
+        _pathResolver = pathResolver;
+    }
+
+    public PreviewResult GetPreview(string path)
+    {
+        var full = _pathResolver.Resolve(path);
+        if (!File.Exists(full))
+            throw new FileNotFoundException();
+
+        var ext = Path.GetExtension(full).ToLowerInvariant();
+        if (ext == ".kml")
+        {
+            var kml = File.ReadAllText(full);
+            var geojson = KmlToGeoJson(kml);
+            return PreviewResult.FromContent(geojson, "application/geo+json");
+        }
+
+        if (!_contentTypeProvider.TryGetContentType(full, out var contentType))
+            contentType = "application/octet-stream";
+
+        return PreviewResult.FromFile(full, contentType);
+    }
+
+    private static string KmlToGeoJson(string kmlContent)
+    {
+        var doc = XDocument.Parse(kmlContent);
+        XNamespace ns = doc.Root!.Name.Namespace;
+        var features = new List<object>();
+
+        static double[] ParseLonLat(string coord)
+        {
+            var parts = coord.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            var lon = double.Parse(parts[0], CultureInfo.InvariantCulture);
+            var lat = double.Parse(parts[1], CultureInfo.InvariantCulture);
+            return new[] { lon, lat };
+        }
+
+        static double[][] ParseCoordinateList(string coordText) =>
+            coordText.Split(new[] { ' ', '\n', '\r', '\t' }, StringSplitOptions.RemoveEmptyEntries)
+                     .Select(ParseLonLat)
+                     .ToArray();
+
+        foreach (var pm in doc.Descendants(ns + "Placemark"))
+        {
+            var name = pm.Element(ns + "name")?.Value;
+            object? geometry = null;
+
+            var point = pm.Element(ns + "Point");
+            if (point != null)
+            {
+                var coordText = point.Element(ns + "coordinates")?.Value.Trim();
+                if (!string.IsNullOrEmpty(coordText))
+                {
+                    geometry = new { type = "Point", coordinates = ParseLonLat(coordText) };
+                }
+            }
+
+            var line = pm.Element(ns + "LineString");
+            if (geometry == null && line != null)
+            {
+                var coordText = line.Element(ns + "coordinates")?.Value;
+                if (!string.IsNullOrEmpty(coordText))
+                {
+                    geometry = new { type = "LineString", coordinates = ParseCoordinateList(coordText) };
+                }
+            }
+
+            var poly = pm.Element(ns + "Polygon");
+            if (geometry == null && poly != null)
+            {
+                var coordText = poly.Descendants(ns + "outerBoundaryIs").Descendants(ns + "coordinates").FirstOrDefault()?.Value;
+                if (!string.IsNullOrEmpty(coordText))
+                {
+                    var coords = ParseCoordinateList(coordText);
+                    geometry = new { type = "Polygon", coordinates = new[] { coords } };
+                }
+            }
+
+            if (geometry != null)
+            {
+                features.Add(new { type = "Feature", properties = new { name }, geometry });
+            }
+        }
+
+        var fc = new { type = "FeatureCollection", features };
+        return JsonSerializer.Serialize(fc);
+    }
+}
+
+public record PreviewResult(string? FilePath, string? Content, string ContentType)
+{
+    public static PreviewResult FromFile(string path, string contentType) => new(path, null, contentType);
+    public static PreviewResult FromContent(string content, string contentType) => new(null, content, contentType);
+}


### PR DESCRIPTION
## Summary
- move file operations into new `FileService`
- move preview conversion into `PreviewService`
- slim down controllers to delegate to services

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68beea22cc68832694b1b6e8739e9c44